### PR TITLE
Enable autoplay and remove duplicate service card

### DIFF
--- a/src/layouts/service.astro
+++ b/src/layouts/service.astro
@@ -94,14 +94,6 @@ import ServiceCard from "../components/serviceCard.astro";
         </li>
         <li class="splide__slide">
           <ServiceCard
-            imageSrc="/image2.png"
-            title="Socmed Manager"
-            description1="Jasa Full Managerial Akun Sosial Media, memastikan akun-mu/bisnis-mu bertumbuh."
-            description2="📱Admin 🚀 META Ads 📈 Strategy & Report"
-          />
-        </li>
-        <li class="splide__slide">
-          <ServiceCard
             imageSrc="/image1.png"
             title="Jasa Lainnya"
             description1="Belum menemukan yang kamu butuhkan? Ekido juga menangani kebutuhan lainnya by request:"
@@ -299,7 +291,7 @@ import ServiceCard from "../components/serviceCard.astro";
   import Splide from "@splidejs/splide";
   document.addEventListener("DOMContentLoaded", function () {
     var splide = new Splide("#serviceSplide", {
-    //   autoplay: true,
+      autoplay: true,
       type: "loop",
     });
     splide.mount();


### PR DESCRIPTION
Autoplay is now enabled for the Splide slider. Removed a duplicate 'Socmed Manager' service card from the list to avoid redundancy.